### PR TITLE
feat: Bump package to support laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         }
     ],
     "require": {
-        "illuminate/macroable": "^10.0.1",
-        "illuminate/support": "^10.0.1",
+        "illuminate/macroable": "^9.0.1|^10.0.1",
+        "illuminate/support": "^9.0.1|^10.0.1",
         "symfony/process": "^5.4|^6.0"
     },
     "autoload": {
@@ -45,7 +45,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.5",
-        "orchestra/testbench": "^8.5.0",
+        "orchestra/testbench": "^7.6.0|^8.5.0",
         "orchestra/testbench-core": "^6.28|^7.0|^8.5",
         "phpunit/phpunit": "^9.5.21"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         }
     ],
     "require": {
-        "illuminate/macroable": "^9.0.1",
-        "illuminate/support": "^9.0.1",
+        "illuminate/macroable": "^10.0.1",
+        "illuminate/support": "^10.0.1",
         "symfony/process": "^5.4|^6.0"
     },
     "autoload": {
@@ -45,8 +45,8 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.5",
-        "orchestra/testbench": "^7.6.0",
-        "orchestra/testbench-core": "^6.28|^7.0",
+        "orchestra/testbench": "^8.5.0",
+        "orchestra/testbench-core": "^6.28|^7.0|^8.5",
         "phpunit/phpunit": "^9.5.21"
     },
     "config": {


### PR DESCRIPTION
PR brings illuminate 10.x support, because currently it's not available to install this package with laravel 10